### PR TITLE
Ability to specify your own currencies to convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm install -g moeda
 #### CLI
 ```
 Usage
-  $ moeda <amount> <currency>
+  $ moeda <amount> <currency> [<...currencies>]
 
 Some currency
   [ usd, eur, gbp, brl... ]
@@ -29,6 +29,18 @@ Result
              Euro: 0.92
   Libra Esterlina: 0.82
    Real Brazilian: 3.15
+
+  Conversion of USD 1
+
+Your own currencies to convert
+
+  $ moeda 1 usd eur rub aud
+
+Result
+
+             Euro: 0.91
+   Russian Rouble: 62.92
+Australian Dollar: 1.30
 
   Conversion of USD 1
 ```

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,14 +5,18 @@ const pkg     = require('../package.json'),
       got     = require('got'),
       money   = require('money'),
       colors  = require('colors'),
-      API     = 'https://api.fixer.io/latest'
+      API     = 'https://api.fixer.io/latest',
+      countrynames = {
+        'RUB': '   Russian Rouble:',
+        'AUD': 'Australian Dollar:',
+        'EUR': '             Euro:'
+      }
 
 
 // arguments
 let argv   = process.argv.slice(2),
     amount = argv[0],
     from   = argv[1]
-
 
 // version
 if(argv.indexOf('--version') !== -1 || argv.indexOf('-v') !== -1) {
@@ -60,6 +64,19 @@ got(API, { json: true }).then(response => {
         '  Real Brazilian:'
       ]
 
+  if(argv.length > 2) {
+    let to = process.argv.slice(4)
+
+    rates = []
+    names = []
+
+    to.map((code) => {
+      code = code.toUpperCase()
+      rates.push(code)
+      names.push(countrynames[code])
+    })
+  }
+
   rates.map((item, index) => {
     if(item != from.toUpperCase()) {
       console.log(` ${names[index].gray.italic} ${money.convert(amount, {
@@ -81,7 +98,7 @@ got(API, { json: true }).then(response => {
 
   }else {
     console.log('   Internal server error... \n'.red)
-    
+
   }
   process.exit(1)
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,10 +6,39 @@ const pkg     = require('../package.json'),
       money   = require('money'),
       colors  = require('colors'),
       API     = 'https://api.fixer.io/latest',
-      countrynames = {
-        'RUB': '   Russian Rouble:',
-        'AUD': 'Australian Dollar:',
-        'EUR': '             Euro:'
+      currencynames = {
+        'RUB': '    Russian Rouble:',
+        'AUD': ' Australian Dollar:',
+        'EUR': '              Euro:',
+        'BGN': '     Bulgarian Lev:',
+        'BRL': '    Real Brazilian:',
+        'CAD': '   Canadian Dollar:',
+        'CHF': '       Swiss Franc:',
+        'CNY': '      Chinese Yuan:',
+        'CZK': '      Czech Koruna:',
+        'DKK': '      Danish Krone:',
+        'GBP': '    British Pounds:',
+        'HKD': '  Hong Kong Dollar:',
+        'HRK': '     Croatian Kuna:',
+        'HUF': '  Hungarian Forint:',
+        'IDR': ' Indonesian Rupiah:',
+        'ILS': '    Israeli Shekel:',
+        'INR': '      Indian Rupee:',
+        'JPY': '       Japanes Yen:',
+        'KRW': '  South Korean Won:',
+        'MXN': '      Mexican Peso:',
+        'MYR': ' Malaysian Ringgit:',
+        'NOK': '   Norwegian Krone:',
+        'PHP': '   Philippine Peso:',
+        'PLN': '      Polish Zloty:',
+        'RON': '  Romanian New Leu:',
+        'SEK': '     Swedish Krona:',
+        'SGD': '  Singapore Dollar:',
+        'THB': '         Thai Baht:',
+        'TRY': '      Turkish Lira:',
+        'USD': '         US Dollar:',
+        'ZAR': 'South African Rand:',
+        'NZD': 'New Zealand Dollar:'
       }
 
 
@@ -30,7 +59,7 @@ if(argv.indexOf('--version') !== -1 || argv.indexOf('-v') !== -1) {
 if(argv.indexOf('--help') !== -1 || argv.indexOf('-h') !== -1 || argv.length == 0) {
   console.log(`
     Usage
-      $ moeda <amount> <currency>
+      $ moeda <amount> <currency> [<...currencies>]
 
     Some currency
       [ usd, eur, gbp, brl... ]
@@ -42,6 +71,18 @@ if(argv.indexOf('--help') !== -1 || argv.indexOf('-h') !== -1 || argv.length == 
                  Euro: 0.92
       Libra Esterlina: 0.82
        Real Brazilian: 3.15
+
+      Conversion of USD 1
+
+    Your own currencies to convert
+
+    $ moeda 1 usd eur rub aud
+
+    Result
+
+                 Euro: 0.91
+       Russian Rouble: 62.92
+    Australian Dollar: 1.30
 
       Conversion of USD 1
   `)
@@ -73,7 +114,7 @@ got(API, { json: true }).then(response => {
     to.map((code) => {
       code = code.toUpperCase()
       rates.push(code)
-      names.push(countrynames[code])
+      names.push(currencynames[code])
     })
   }
 


### PR DESCRIPTION
Added abilty to specify currencies for convert. For use this: 

`$ moeda <amount> <currency> [<...currencies>]`

Example: 
```
$ moeda 1 usd eur rub aud

Result

             Euro: 0.91
   Russian Rouble: 62.92
Australian Dollar: 1.30

  Conversion of USD 1

```

Now we can use for conversions all currencies from fixer.io with their names.

All changes also in updated README.