### PR TITLE
added CRC, costa rican colon to currencies

### DIFF
--- a/lib/currencies.json
+++ b/lib/currencies.json
@@ -30,5 +30,7 @@
   "TRY": "      Turkish Lira:",
   "USD": "         US Dollar:",
   "ZAR": "South African Rand:",
-  "NZD": "New Zealand Dollar:"
+  "NZD": "New Zealand Dollar:",
+  "CRC": "Costa Rican Colon:"
+
 }


### PR DESCRIPTION
Added (CRC) costa rica currency to the currencies.json
